### PR TITLE
Fixed issue with Popover in Modal.

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,12 @@ Required
         type: 'text',
         pk: 1,
         url: '/post',
-        title: 'Enter username'
+        title: 'Enter Username',
+        popupOptions: {
+            container: '.my-awesome-container-class',
+            animation: true,
+            placement: 'right',
+        }
     });
     ```
 5. Frontend ready!\
@@ -110,7 +115,7 @@ Options can be defined via javascript or via data-* html attributes.
 
 | Name         | Type            | Default        | Description                                                                                                                                              |
 |--------------|-----------------|----------------|----------------------------------------------------------------------------------------------------------------------------------------------------------|
-| ajaxOptions  | object          | null           | Text shown when element is empty                                                                                                                         |
+| ajaxOptions  | object          | null           |                                                                                                                          |
 | disabled     | boolean         | false          | Sets disabled state of editable                                                                                                                          |
 | emptytext    | string          | 'Empty'        | Text shown when element is empty.                                                                                                                        |
 | error        | function        | null           |                                                                                                                                                          |
@@ -123,6 +128,7 @@ Options can be defined via javascript or via data-* html attributes.
 | url          | string          | null           | Url for submit, e.g. ```'/post'```                                                                                                                       |
 | value        | mixed           | element's text | Initial value of input. If not set, taken from element's text.                                                                                           |
 | mode         | string          | 'popup'        | Mode of editable, can be popup or inline.                                                                                                                |
+| popupOptions | object          | null           | Bootstrap Popover Options. Work only in mode 'popup'.                                                                                                                |
 # Methods
 | Method          | Parameters                    | Description                                 |
 |-----------------|-------------------------------|---------------------------------------------|

--- a/src/Interfaces/Options.ts
+++ b/src/Interfaces/Options.ts
@@ -10,6 +10,7 @@ export default interface Options {
     disabled?: boolean;
     send?: boolean;
     mode?: 'popup'|'inline';
+    popupOptions?: Record<string, any>;
     emptytext?: string;
     url?: string|null;
     required?: boolean;

--- a/src/Modes/PopupMode.ts
+++ b/src/Modes/PopupMode.ts
@@ -6,13 +6,14 @@ export default class PopupMode extends BaseMode{
     popover: Popover|null = null;
 
     init(){
-        this.popover = new Popover(this.context.element, {
-            container: this.context.element.closest(".modal") ? ".modal-content" : "body",
-            content: this.context.typeElement.create(),
-            html: true,
-            customClass: "dark-editable",
-            title: this.context.options.title,
-        });
+        const options = this.context.options.popupOptions || {};
+        if (!("container" in options)) {
+            options.container = this.context.element.closest(".modal") ? ".modal-content" : "body";
+        }
+        options.html = true;
+        options.content = this.context.typeElement.create();
+
+        this.popover = new Popover(this.context.element, options);
         this.context.element.addEventListener('show.bs.popover', () => {
             this.event_show();
         });

--- a/src/Modes/PopupMode.ts
+++ b/src/Modes/PopupMode.ts
@@ -7,7 +7,7 @@ export default class PopupMode extends BaseMode{
 
     init(){
         this.popover = new Popover(this.context.element, {
-            container: "body",
+            container: this.context.element.closest(".modal") ? ".modal-content" : "body",
             content: this.context.typeElement.create(),
             html: true,
             customClass: "dark-editable",

--- a/src/dark-editable.ts
+++ b/src/dark-editable.ts
@@ -70,15 +70,22 @@ export default class DarkEditable{
 
     init_options(): void
     {
+        // for backward compatibility
+        const title = this.get_opt("title", "");
+
         //priority date elements
         this.get_opt("value", this.element.innerHTML);
         this.get_opt("name", this.element.id);
         this.get_opt("pk", null);
-        this.get_opt("title", "");
         this.get_opt("type", "text");
         this.get_opt("emptytext", "Empty");
         this.get_opt("mode", "popup");
         this.get_opt("url", null);
+        this.get_opt("popupOptions", {});
+        this.options.popupOptions = Object.assign({
+            customClass: "dark-editable",
+            title: title,
+        }, this.options.popupOptions);
         this.get_opt("ajaxOptions", {});
         this.options.ajaxOptions = Object.assign({
             method: "POST",


### PR DESCRIPTION
This is particularly important for popovers that contain interactive elements – modal dialogs will trap focus, so unless the popover is a child element of the modal, users won’t be able to focus or activate these interactive elements.

https://getbootstrap.com/docs/5.3/components/popovers/#custom-container